### PR TITLE
Fix emploi page schedule display

### DIFF
--- a/lib/pages/emploi_page.dart
+++ b/lib/pages/emploi_page.dart
@@ -43,6 +43,7 @@ class _EmploiPageState extends State<EmploiPage> {
     setState(() {
       _isLoading = true;
       _message = null;
+      emplois = {}; // réinitialise le tableau affiché
     });
 
     try {
@@ -52,6 +53,7 @@ class _EmploiPageState extends State<EmploiPage> {
         emplois = result;
         _message = "✅ Emploi du temps généré avec succès !";
       });
+      debugPrint('Emplois récupérés: $result');
     } catch (e) {
       setState(() {
         _message = "❌ Erreur : $e";
@@ -149,7 +151,18 @@ class _EmploiPageState extends State<EmploiPage> {
             const SizedBox(height: 10),
 
             if (emplois.isNotEmpty)
-              Expanded(child: EmploiTable(emploiData: emplois)),
+              Expanded(
+                child: SingleChildScrollView(
+                  child: Card(
+                    elevation: 2,
+                    margin: const EdgeInsets.only(top: 8),
+                    child: Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: EmploiTable(emploiData: emplois),
+                    ),
+                  ),
+                ),
+              ),
           ],
         ),
       ),

--- a/lib/widgets/emploi_table.dart
+++ b/lib/widgets/emploi_table.dart
@@ -19,6 +19,7 @@ class EmploiTable extends StatelessWidget {
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
       child: DataTable(
+        headingRowColor: MaterialStatePropertyAll(Colors.tealAccent),
         columns: [
           const DataColumn(label: Text('Heure')),
           ...jours.map((jour) => DataColumn(label: Text(jour))),


### PR DESCRIPTION
## Summary
- clear previous timetable before regeneration and log retrieved data
- wrap EmploiTable in a scrollable card for visibility
- add heading color styling to the table

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6850386433b0832d95c811b582f9faa8