### PR TITLE
Add planning parser and import features

### DIFF
--- a/lib/pages/dashboard.dart
+++ b/lib/pages/dashboard.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'add_entity_page.dart';
 import 'entity_list_page.dart';
 import 'emploi_page.dart'; // ✅ Assure-toi que ce fichier existe bien dans ce dossier
+import 'planning_import_page.dart';
+import 'emploi_global_page.dart';
 
 class DashboardPage extends StatelessWidget {
   const DashboardPage({super.key});
@@ -114,6 +116,10 @@ class AppDrawer extends StatelessWidget {
           // ✅ Lien vers l’emploi du temps
           drawerItem(context, "Générer Emploi du Temps", Icons.event_available,
                   () => EmploiPage()), // ✅ const supprimé ici aussi
+          drawerItem(context, "Importer Planning", Icons.upload_file,
+                  () => const PlanningImportPage()),
+          drawerItem(context, "Emploi global", Icons.table_rows,
+                  () => const EmploiGlobalPage()),
         ],
       ),
     );

--- a/lib/pages/emploi_global_page.dart
+++ b/lib/pages/emploi_global_page.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../services/emploi_generator.dart';
+import '../widgets/emploi_table.dart';
+
+class EmploiGlobalPage extends StatefulWidget {
+  const EmploiGlobalPage({super.key});
+
+  @override
+  State<EmploiGlobalPage> createState() => _EmploiGlobalPageState();
+}
+
+class _EmploiGlobalPageState extends State<EmploiGlobalPage> {
+  final EmploiGenerator _generator = EmploiGenerator();
+  List<String> _filieres = [];
+  String? _filiere;
+  Map<String, Map<String, Map<String, String>>> _emploiParClasse = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _chargerFilieres();
+  }
+
+  Future<void> _chargerFilieres() async {
+    final snapshot = await FirebaseFirestore.instance.collection('classes').get();
+    final fil = snapshot.docs.map((e) => e['filiere'] as String).toSet().toList();
+    setState(() {
+      _filieres = fil;
+      if (fil.isNotEmpty) _filiere = fil.first;
+    });
+    if (fil.isNotEmpty) {
+      _chargerEmplois();
+    }
+  }
+
+  Future<void> _chargerEmplois() async {
+    if (_filiere == null) return;
+    final classesSnapshot = await FirebaseFirestore.instance
+        .collection('classes')
+        .where('filiere', isEqualTo: _filiere)
+        .get();
+    Map<String, Map<String, Map<String, String>>> data = {};
+    for (final classe in classesSnapshot.docs) {
+      final emplois = await _generator.getEmploisParClasse(classe.id);
+      data[classe['nom']] = emplois;
+    }
+    setState(() {
+      _emploiParClasse = data;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Emplois par filière')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            DropdownButton<String>(
+              value: _filiere,
+              items: _filieres
+                  .map((f) => DropdownMenuItem<String>(value: f, child: Text(f)))
+                  .toList(),
+              onChanged: (val) {
+                setState(() {
+                  _filiere = val;
+                });
+                _chargerEmplois();
+              },
+            ),
+            const SizedBox(height: 20),
+            Expanded(
+              child: ListView(
+                children: _emploiParClasse.entries.map((entry) {
+                  return Card(
+                    margin: const EdgeInsets.only(bottom: 16),
+                    child: Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(entry.key, style: const TextStyle(fontWeight: FontWeight.bold)),
+                          const SizedBox(height: 8),
+                          EmploiTable(emploiData: entry.value),
+                        ],
+                      ),
+                    ),
+                  );
+                }).toList(),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/planning_import_page.dart
+++ b/lib/pages/planning_import_page.dart
@@ -1,0 +1,98 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:http/http.dart' as http;
+import '../services/emploi_generator.dart';
+
+class PlanningImportPage extends StatefulWidget {
+  const PlanningImportPage({super.key});
+
+  @override
+  State<PlanningImportPage> createState() => _PlanningImportPageState();
+}
+
+class _PlanningImportPageState extends State<PlanningImportPage> {
+  String? _filePath;
+  bool _loading = false;
+  String? _message;
+  final EmploiGenerator _generator = EmploiGenerator();
+
+  Future<void> _pickFile() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['docx'],
+    );
+    if (result != null && result.files.single.path != null) {
+      setState(() {
+        _filePath = result.files.single.path;
+      });
+    }
+  }
+
+  Future<void> _sendFile() async {
+    if (_filePath == null) return;
+    setState(() {
+      _loading = true;
+      _message = null;
+    });
+    final request = http.MultipartRequest(
+      'POST',
+      Uri.parse('http://localhost:8000/parse-word'),
+    );
+    request.files.add(await http.MultipartFile.fromPath('file', _filePath!));
+    final response = await request.send();
+    final body = await response.stream.bytesToString();
+    if (response.statusCode == 200) {
+      final data = json.decode(body) as Map<String, dynamic>;
+      await _generator.importerDepuisJson(data);
+      setState(() {
+        _message = 'Planning importé avec succès';
+      });
+    } else {
+      setState(() {
+        _message = "Erreur lors de l'import";
+      });
+    }
+    setState(() {
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Importer un planning')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            ElevatedButton.icon(
+              onPressed: _pickFile,
+              icon: const Icon(Icons.attach_file),
+              label: const Text('Sélectionner le fichier Word'),
+            ),
+            const SizedBox(height: 10),
+            Text(_filePath ?? 'Aucun fichier sélectionné'),
+            const SizedBox(height: 20),
+            _loading
+                ? const Center(child: CircularProgressIndicator())
+                : ElevatedButton.icon(
+                    onPressed: _sendFile,
+                    icon: const Icon(Icons.upload),
+                    label: const Text('Envoyer et importer'),
+                  ),
+            if (_message != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 20),
+                child: Text(
+                  _message!,
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/pdf_exporter.dart
+++ b/lib/services/pdf_exporter.dart
@@ -1,0 +1,54 @@
+import 'dart:io';
+import 'package:pdf/widgets.dart' as pw;
+import 'package:printing/printing.dart';
+
+class PdfExporter {
+  Future<void> exportEmploi(String path, Map<String, Map<String, String>> emploi,
+      {String title = 'Emploi du temps'}) async {
+    final pdf = pw.Document();
+
+    pdf.addPage(
+      pw.Page(
+        build: (context) {
+          return pw.Column(
+            crossAxisAlignment: pw.CrossAxisAlignment.start,
+            children: [
+              pw.Text(title, style: pw.TextStyle(fontSize: 18)),
+              pw.SizedBox(height: 20),
+              _buildTable(emploi),
+            ],
+          );
+        },
+      ),
+    );
+
+    final file = File(path);
+    await file.writeAsBytes(await pdf.save());
+  }
+
+  pw.Widget _buildTable(Map<String, Map<String, String>> data) {
+    final jours = [
+      'Lundi',
+      'Mardi',
+      'Mercredi',
+      'Jeudi',
+      'Vendredi',
+      'Samedi',
+    ];
+    final heures = [
+      '07H30 - 10H15',
+      '10H30 - 13H15',
+      '14H00 - 16H45',
+    ];
+
+    return pw.Table.fromTextArray(
+      headers: ['Heure', ...jours],
+      data: heures.map((h) {
+        return [
+          h,
+          ...jours.map((j) => data[j]?[h] ?? '').toList(),
+        ];
+      }).toList(),
+    );
+  }
+}

--- a/parser_api.py
+++ b/parser_api.py
@@ -1,0 +1,48 @@
+from fastapi import FastAPI, File, UploadFile
+from fastapi.responses import JSONResponse
+from docx import Document
+from typing import Dict
+import uvicorn
+
+app = FastAPI()
+
+
+def parse_docx(path: str) -> Dict[str, Dict[str, Dict[str, str]]]:
+    """Very basic parser returning data grouped by class."""
+    doc = Document(path)
+    result: Dict[str, Dict[str, Dict[str, str]]] = {}
+
+    for table in doc.tables:
+        for row in table.rows:
+            cells = [c.text.strip() for c in row.cells]
+            if len(cells) >= 4:
+                classe = cells[0].replace(' ', '_')
+                jour = cells[1]
+                heure = cells[2]
+                detail = cells[3]
+                result.setdefault(classe, {}).setdefault(jour, {})[heure] = detail
+    # fallback: try paragraphs formatted with commas
+    if not result:
+        for para in doc.paragraphs:
+            parts = [p.strip() for p in para.text.split(',')]
+            if len(parts) >= 4:
+                classe = parts[0].replace(' ', '_')
+                jour = parts[1]
+                heure = parts[2]
+                detail = ','.join(parts[3:]).strip()
+                result.setdefault(classe, {}).setdefault(jour, {})[heure] = detail
+    return result
+
+
+@app.post("/parse-word")
+async def parse_word(file: UploadFile = File(...)):
+    data = await file.read()
+    tmp_path = f"/tmp/{file.filename}"
+    with open(tmp_path, "wb") as f:
+        f.write(data)
+    parsed = parse_docx(tmp_path)
+    return JSONResponse(content=parsed)
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,10 @@ dependencies:
   cloud_firestore_web: ^3.7.4
   firebase_storage_web: ^3.5.4
   js: ^0.6.7
+  http: ^1.1.0
+  file_picker: ^6.1.1
+  pdf: ^3.10.4
+  printing: ^5.11.0
 
 dev_dependencies:
   flutter_test:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+python-docx


### PR DESCRIPTION
## Summary
- create FastAPI `parser_api.py` to read docx files
- export `requirements.txt` for Python server
- add import screen and global schedule screen in Flutter
- support JSON import into Firestore via `importerDepuisJson`
- enable PDF export utilities
- extend dashboard menu and dependencies

## Testing
- `python3 -m py_compile parser_api.py`
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685172740774832dabf4792959cde09f