### PR TITLE
Add parser API and Flutter import pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # emploi_temps_admin
 
-A new Flutter project.
+A Flutter app to manage university schedules.
 
 ## Getting Started
 
@@ -14,3 +14,13 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Backend parser
+
+`parser_api.py` exposes a FastAPI endpoint `/parse-word` to parse planning `.docx` files.
+Run it with:
+
+```bash
+pip install -r requirements.txt
+python parser_api.py
+```

--- a/lib/pages/dashboard.dart
+++ b/lib/pages/dashboard.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'add_entity_page.dart';
 import 'entity_list_page.dart';
 import 'emploi_page.dart'; // ✅ Assure-toi que ce fichier existe bien dans ce dossier
+import 'planning_import_page.dart';
+import 'emploi_global_page.dart';
 
 class DashboardPage extends StatelessWidget {
   const DashboardPage({super.key});
@@ -114,6 +116,10 @@ class AppDrawer extends StatelessWidget {
           // ✅ Lien vers l’emploi du temps
           drawerItem(context, "Générer Emploi du Temps", Icons.event_available,
                   () => EmploiPage()), // ✅ const supprimé ici aussi
+          drawerItem(context, "Importer Planning", Icons.upload_file,
+                  () => const PlanningImportPage()),
+          drawerItem(context, "Emploi Global", Icons.table_chart,
+                  () => const EmploiGlobalPage()),
         ],
       ),
     );

--- a/lib/pages/emploi_global_page.dart
+++ b/lib/pages/emploi_global_page.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../services/emploi_generator.dart';
+import '../widgets/emploi_table.dart';
+
+class EmploiGlobalPage extends StatefulWidget {
+  const EmploiGlobalPage({super.key});
+
+  @override
+  State<EmploiGlobalPage> createState() => _EmploiGlobalPageState();
+}
+
+class _EmploiGlobalPageState extends State<EmploiGlobalPage> {
+  final EmploiGenerator _generator = EmploiGenerator();
+  String? _selectedFiliereId;
+  String? _selectedClassId;
+  List<Map<String, dynamic>> _filieres = [];
+  List<Map<String, dynamic>> _classes = [];
+  Map<String, Map<String, String>> emplois = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _loadFilieres();
+  }
+
+  Future<void> _loadFilieres() async {
+    final snap = await FirebaseFirestore.instance.collection('filieres').get();
+    setState(() {
+      _filieres =
+          snap.docs.map((d) => {'id': d.id, 'nom': d['nom'] ?? 'Filière'}).toList();
+      if (_filieres.isNotEmpty) {
+        _selectedFiliereId = _filieres.first['id'];
+        _loadClasses();
+      }
+    });
+  }
+
+  Future<void> _loadClasses() async {
+    if (_selectedFiliereId == null) return;
+    final classesSnap = await FirebaseFirestore.instance
+        .collection('classes')
+        .where('filiere', isEqualTo: _selectedFiliereId)
+        .get();
+    setState(() {
+      _classes = classesSnap.docs
+          .map((c) => {'id': c.id, 'nom': c['nom']})
+          .toList();
+      if (_classes.isNotEmpty) {
+        _selectedClassId = _classes.first['id'];
+      }
+    });
+  }
+
+  Future<void> _loadEmploi() async {
+    if (_selectedClassId == null) return;
+    final data = await _generator.getEmploisParClasse(_selectedClassId!);
+    setState(() => emplois = data);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Emplois du temps')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: DropdownButton<String>(
+                    value: _selectedFiliereId,
+                    hint: const Text('Filière'),
+                    isExpanded: true,
+                    items: _filieres
+                        .map((f) => DropdownMenuItem(
+                              value: f['id'],
+                              child: Text(f['nom']),
+                            ))
+                        .toList(),
+                    onChanged: (val) {
+                      setState(() {
+                        _selectedFiliereId = val;
+                        _loadClasses();
+                      });
+                    },
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: DropdownButton<String>(
+                    value: _selectedClassId,
+                    hint: const Text('Classe'),
+                    isExpanded: true,
+                    items: _classes
+                        .map((c) => DropdownMenuItem(
+                              value: c['id'],
+                              child: Text(c['nom']),
+                            ))
+                        .toList(),
+                    onChanged: (val) {
+                      setState(() {
+                        _selectedClassId = val;
+                      });
+                    },
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.search),
+                  onPressed: _loadEmploi,
+                )
+              ],
+            ),
+            const SizedBox(height: 20),
+            if (emplois.isNotEmpty)
+              Expanded(child: EmploiTable(emploiData: emplois)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/planning_import_page.dart
+++ b/lib/pages/planning_import_page.dart
@@ -1,0 +1,76 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:http/http.dart' as http;
+
+import '../services/emploi_generator.dart';
+
+class PlanningImportPage extends StatefulWidget {
+  const PlanningImportPage({super.key});
+
+  @override
+  State<PlanningImportPage> createState() => _PlanningImportPageState();
+}
+
+class _PlanningImportPageState extends State<PlanningImportPage> {
+  bool _loading = false;
+  String? _message;
+  final EmploiGenerator _generator = EmploiGenerator();
+
+  Future<void> _importPlanning() async {
+    final result = await FilePicker.platform.pickFiles(
+        type: FileType.custom, allowedExtensions: ['docx']);
+    if (result == null) return;
+    final path = result.files.single.path!;
+
+    setState(() {
+      _loading = true;
+      _message = null;
+    });
+
+    try {
+      final request = http.MultipartRequest(
+          'POST', Uri.parse('http://localhost:8000/parse-word'));
+      request.files.add(await http.MultipartFile.fromPath('file', path));
+      final streamed = await request.send();
+      final body = await streamed.stream.bytesToString();
+      if (streamed.statusCode == 200) {
+        final data = jsonDecode(body) as Map<String, dynamic>;
+        await _generator.importFromJson(data);
+        setState(() => _message = 'Import réussi');
+      } else {
+        setState(() => _message = 'Erreur serveur');
+      }
+    } catch (e) {
+      setState(() => _message = 'Erreur : $e');
+    } finally {
+      setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Importer un planning')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            ElevatedButton(
+              onPressed: _loading ? null : _importPlanning,
+              child: const Text('Sélectionner un fichier Word'),
+            ),
+            const SizedBox(height: 20),
+            if (_loading) const CircularProgressIndicator(),
+            if (_message != null) Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Text(_message!),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/pdf_exporter.dart
+++ b/lib/services/pdf_exporter.dart
@@ -1,0 +1,58 @@
+import 'package:pdf/widgets.dart' as pw;
+import 'package:pdf/pdf.dart';
+import 'package:printing/printing.dart';
+
+class PdfExporter {
+  Future<void> export(Map<String, Map<String, String>> data, String title) async {
+    final doc = pw.Document();
+    final jours = ['Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi'];
+    final heures = [
+      '07H30 - 10H15',
+      '10H30 - 13H15',
+      '14H00 - 16H45'
+    ];
+
+    doc.addPage(
+      pw.Page(
+        pageFormat: PdfPageFormat.a4,
+        build: (context) {
+          return pw.Column(
+            children: [
+              pw.Text(title, style: pw.TextStyle(fontSize: 18)),
+              pw.SizedBox(height: 20),
+              pw.Table(
+                border: pw.TableBorder.all(),
+                children: [
+                  pw.TableRow(
+                    children: [
+                      pw.Container(),
+                      ...jours.map((j) => pw.Padding(
+                            padding: const pw.EdgeInsets.all(4),
+                            child: pw.Text(j),
+                          ))
+                    ],
+                  ),
+                  ...heures.map(
+                    (h) => pw.TableRow(
+                      children: [
+                        pw.Padding(
+                            padding: const pw.EdgeInsets.all(4), child: pw.Text(h)),
+                        ...jours.map((j) {
+                          final text = data[j]?[h] ?? '';
+                          return pw.Padding(
+                              padding: const pw.EdgeInsets.all(4), child: pw.Text(text));
+                        })
+                      ],
+                    ),
+                  )
+                ],
+              )
+            ],
+          );
+        },
+      ),
+    );
+
+    await Printing.layoutPdf(onLayout: (format) async => doc.save());
+  }
+}

--- a/parser_api.py
+++ b/parser_api.py
@@ -1,0 +1,46 @@
+from fastapi import FastAPI, File, UploadFile
+from fastapi.responses import JSONResponse
+from docx import Document
+from typing import Dict
+import os
+import uvicorn
+
+app = FastAPI()
+
+
+def parse_docx(path: str) -> Dict[str, Dict[str, Dict[str, str]]]:
+    """Parse the planning Word document and return a nested dict."""
+    planning: Dict[str, Dict[str, Dict[str, str]]] = {}
+    doc = Document(path)
+    current_class = None
+    for para in doc.paragraphs:
+        text = para.text.strip()
+        if not text:
+            continue
+        if text.upper().startswith("TIC"):
+            current_class = text.replace(' ', '_')
+            planning[current_class] = {}
+        elif any(jour in text for jour in ["Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi"]):
+            parts = text.split(':')
+            if len(parts) == 2 and current_class:
+                day = parts[0].strip()
+                hour_course = parts[1].strip()
+                if ' ' in hour_course:
+                    hour, course = hour_course.split(' ', 1)
+                    planning[current_class].setdefault(day, {})[hour] = course
+    return planning
+
+
+@app.post('/parse-word')
+async def parse_word(file: UploadFile = File(...)):
+    contents = await file.read()
+    tmp_path = f"temp_{file.filename}"
+    with open(tmp_path, 'wb') as f:
+        f.write(contents)
+    result = parse_docx(tmp_path)
+    os.remove(tmp_path)
+    return JSONResponse(content=result)
+
+
+if __name__ == '__main__':
+    uvicorn.run(app, host='0.0.0.0', port=8000)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,10 @@ dependencies:
   cloud_firestore_web: ^3.7.4
   firebase_storage_web: ^3.5.4
   js: ^0.6.7
+  http: ^1.1.0
+  file_picker: ^6.1.1
+  pdf: ^3.10.5
+  printing: ^5.12.0
 
 dev_dependencies:
   flutter_test:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+python-docx


### PR DESCRIPTION
## Summary
- implement `parser_api.py` with FastAPI to extract planning data from Word docs
- expose `/parse-word` endpoint
- add `planning_import_page` to upload Word docs and import schedules
- add `emploi_global_page` to browse timetables by filière and class
- extend `EmploiGenerator` with JSON import helper
- provide PDF export utility
- register new pages in dashboard drawer
- document parser API usage in README
- declare additional dependencies for Flutter

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart format -o none -l 120 $(git ls-files '*.dart')` *(fails: command not found)*
- `python parser_api.py` *(fails: ModuleNotFoundError: No module named 'docx')*

------
https://chatgpt.com/codex/tasks/task_e_685172740774832dabf4792959cde09f