### PR TITLE
Fix Flask integration and update Android configs

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 android {
     namespace = "com.example.emploi_temps_admin"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     <application
         android:label="emploi_temps_admin"
         android:name="${applicationName}"
+        android:enableOnBackInvokedCallback="true"
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,47 @@
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+from docx import Document
+import io
+
+app = Flask(__name__)
+CORS(app)
+
+@app.route('/parse-word', methods=['POST'])
+def parse_word():
+    """Receive a .docx file and return parsed JSON data."""
+    if 'file' not in request.files:
+        return jsonify({'error': 'No file part'}), 400
+    uploaded_file = request.files['file']
+    if uploaded_file.filename == '':
+        return jsonify({'error': 'No selected file'}), 400
+
+    doc_bytes = uploaded_file.read()
+    document = Document(io.BytesIO(doc_bytes))
+    emplois = []
+
+    if document.tables:
+        table = document.tables[0]
+        rows = table.rows
+        for row in rows[1:]:
+            cells = [c.text.strip() for c in row.cells]
+            if cells:
+                entry = {}
+                keys = ['classe', 'jour', 'heure', 'module', 'prof', 'salle']
+                for idx, key in enumerate(keys):
+                    if idx < len(cells):
+                        entry[key] = cells[idx]
+                emplois.append(entry)
+    else:
+        for para in document.paragraphs:
+            line = para.text.strip()
+            if not line:
+                continue
+            parts = [p.strip() for p in line.split('|')]
+            if len(parts) >= 6:
+                entry = dict(zip(['classe', 'jour', 'heure', 'module', 'prof', 'salle'], parts[:6]))
+                emplois.append(entry)
+
+    return jsonify({'emplois': emplois})
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)

--- a/lib/pages/planning_import_page.dart
+++ b/lib/pages/planning_import_page.dart
@@ -40,24 +40,31 @@ class _PlanningImportPageState extends State<PlanningImportPage> {
       _message = null;
     });
 
-    final request = http.MultipartRequest(
-      'POST',
-      Uri.parse('http://localhost:8000/parse-word'),
-    );
-    request.files.add(await http.MultipartFile.fromPath('file', _filePath!));
+    try {
+      final request = http.MultipartRequest(
+        'POST',
+        // Sur l'émulateur Android, "localhost" doit être remplacé par 10.0.2.2
+        Uri.parse('http://10.0.2.2:8000/parse-word'),
+      );
+      request.files.add(await http.MultipartFile.fromPath('file', _filePath!));
 
-    final response = await request.send();
-    final body = await response.stream.bytesToString();
+      final response = await request.send();
+      final body = await response.stream.bytesToString();
 
-    if (response.statusCode == 200) {
-      final data = json.decode(body) as Map<String, dynamic>;
-      await _generator.importerDepuisJson(data);
+      if (response.statusCode == 200) {
+        final data = json.decode(body) as Map<String, dynamic>;
+        await _generator.importerDepuisJson(data);
+        setState(() {
+          _message = 'Planning importé avec succès';
+        });
+      } else {
+        setState(() {
+          _message = "Erreur lors de l'importation du fichier";
+        });
+      }
+    } catch (e) {
       setState(() {
-        _message = 'Planning importé avec succès';
-      });
-    } else {
-      setState(() {
-        _message = "Erreur lors de l'importation du fichier";
+        _message = 'Erreur : $e';
       });
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,18 +35,17 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   firebase_core: ^2.32.0
-  cloud_firestore: ^4.8.4
-  firebase_auth: ^4.11.1
-  firebase_storage: ^11.5.2
-  flutter_hooks: ^0.20.3
-  firebase_auth_web: ^5.7.4
-  cloud_firestore_web: ^3.7.4
-  firebase_storage_web: ^3.5.4
-  js: ^0.6.7
-  http: ^1.1.0
-  file_selector: ^1.0.3
-  pdf: ^3.10.4
-  printing: ^5.11.0
+  cloud_firestore: ^4.15.0
+  firebase_auth: ^4.17.0
+  firebase_storage: ^11.6.0
+  flutter_hooks: ^0.20.5
+  firebase_auth_web: ^5.8.0
+  cloud_firestore_web: ^3.8.0
+  firebase_storage_web: ^3.6.0
+  http: ^1.2.1
+  file_selector: ^1.0.4
+  pdf: ^3.10.8
+  printing: ^5.12.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- move Flask `app.py` under new `backend` folder
- update planning import call to work with Android emulator and add error handling
- set explicit NDK version
- enable `OnBackInvokedCallback` in AndroidManifest
- bump dependencies and remove unused `js`

## Testing
- `python3 -m py_compile backend/app.py`


------
https://chatgpt.com/codex/tasks/task_e_6851e63baddc832dbe65462e82544c10