### PR TITLE
Ajout importation Excel

### DIFF
--- a/lib/pages/dashboard.dart
+++ b/lib/pages/dashboard.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'add_entity_page.dart';
 import 'entity_list_page.dart';
 import 'emploi_page.dart';
-import 'planning_import_page.dart';
+import 'import_excel_page.dart';
 import 'emploi_global_page.dart';
 import 'add_module_page.dart';
 import 'module_list_page.dart';
@@ -26,7 +26,7 @@ class DashboardPage extends StatelessWidget {
             onPressed: () {
               Navigator.push(
                 context,
-                MaterialPageRoute(builder: (_) => const PlanningImportPage()),
+                MaterialPageRoute(builder: (_) => const ImportExcelPage()),
               );
             },
           ),
@@ -144,7 +144,7 @@ class AppDrawer extends StatelessWidget {
           drawerItem(context, "Générer Emploi du Temps", Icons.event_available,
                   () => EmploiPage()), // ✅ const supprimé ici aussi
           drawerItem(context, "Importer Planning", Icons.upload_file,
-                  () => const PlanningImportPage()),
+                  () => const ImportExcelPage()),
           drawerItem(context, "Emploi global", Icons.table_rows,
                   () => const EmploiGlobalPage()),
         ],

--- a/lib/services/excel_importer.dart
+++ b/lib/services/excel_importer.dart
@@ -1,0 +1,83 @@
+import 'dart:io';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:excel/excel.dart';
+
+/// Service permettant d'importer un planning depuis un fichier Excel
+class ExcelImporter {
+  final FirebaseFirestore _db = FirebaseFirestore.instance;
+
+  /// Lit le fichier [path], insère les emplois dans Firestore et renvoie
+  /// le nombre d'entrées importées.
+  Future<int> importFile(String path) async {
+    final bytes = File(path).readAsBytesSync();
+    final excel = Excel.decodeBytes(bytes);
+
+    // Collecte des entrées sous forme de Map<String, String>
+    final List<Map<String, String>> lignes = [];
+    for (final table in excel.tables.values) {
+      for (var rowIndex = 1; rowIndex < table.maxRows; rowIndex++) {
+        final row = table.row(rowIndex);
+        if (row.isEmpty) continue;
+        final classe = row[0]?.value?.toString();
+        final jour = row.length > 1 ? row[1]?.value?.toString() : null;
+        final heure = row.length > 2 ? row[2]?.value?.toString() : null;
+        final module = row.length > 3 ? row[3]?.value?.toString() : null;
+        final prof = row.length > 4 ? row[4]?.value?.toString() : null;
+        final salle = row.length > 5 ? row[5]?.value?.toString() : null;
+        if ([classe, jour, heure, module, prof, salle].contains(null)) continue;
+        lignes.add({
+          'classe': classe!,
+          'jour': jour!,
+          'heure': heure!,
+          'module': module!,
+          'prof': prof!,
+          'salle': salle!,
+        });
+      }
+    }
+
+    if (lignes.isEmpty) return 0;
+
+    // Récupération des références Firestore
+    final classes = await _db.collection('classes').get();
+    final salles = await _db.collection('salles').get();
+    final modules = await _db.collection('modules').get();
+    final profs = await _db.collection('professeurs').get();
+
+    final classesMap = {for (var c in classes.docs) c.data()['nom']: c.id};
+    final sallesMap = {for (var s in salles.docs) s.data()['nom']: s.id};
+    final modulesMap = {for (var m in modules.docs) m.data()['nom']: m.id};
+    final profsMap = {for (var p in profs.docs) p.data()['nom']: p.id};
+
+    // Nettoyage des anciens emplois
+    final anciens = await _db.collection('emplois').get();
+    for (final doc in anciens.docs) {
+      await doc.reference.delete();
+    }
+
+    int count = 0;
+    for (final e in lignes) {
+      final classeId = classesMap[e['classe']];
+      final moduleId = modulesMap[e['module']];
+      final profId = profsMap[e['prof']];
+      final salleId = sallesMap[e['salle']];
+      final jour = e['jour'];
+      final heure = e['heure'];
+
+      if ([classeId, moduleId, profId, salleId, jour, heure].contains(null)) {
+        continue;
+      }
+
+      await _db.collection('emplois').add({
+        'classe': classeId,
+        'jour': jour,
+        'heure': heure,
+        'module': moduleId,
+        'prof': profId,
+        'salle': salleId,
+      });
+      count++;
+    }
+    return count;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,8 @@ dependencies:
   firebase_storage_web: ^3.6.0
   http: ^1.2.1
   file_selector: ^1.0.4
+  file_picker: ^6.1.1
+  excel: ^2.0.0
   pdf: ^3.10.8
   printing: ^5.12.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,8 +22,8 @@ dependencies:
   firebase_storage_web: ^3.6.0
   http: ^1.2.1
   file_selector: ^1.0.4
-  file_picker: ^6.1.1
-  excel: ^2.0.0
+  file_picker: ^6.2.1
+  excel: ^2.1.0
   pdf: ^3.10.8
   printing: ^5.12.0
 


### PR DESCRIPTION
## Summary
- remove legacy Word import page
- add Excel import service and page
- wire dashboard links to Excel importer
- add `file_picker` and `excel` dependencies

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685852819074832da373139a4c149458