### PR TITLE
Add JSON schedule import

### DIFF
--- a/assets/emploi_test.json
+++ b/assets/emploi_test.json
@@ -1,0 +1,12 @@
+{
+  "emplois": [
+    {
+      "classe": "TIC L2",
+      "jour": "Lundi",
+      "heure": "07H30 - 10H15",
+      "module": "Programmation avancée",
+      "salle": "Salle S3",
+      "prof": "Dr. NKO’O"
+    }
+  ]
+}

--- a/lib/pages/dashboard.dart
+++ b/lib/pages/dashboard.dart
@@ -8,6 +8,7 @@ import 'add_module_page.dart';
 import 'module_list_page.dart';
 import 'add_filiere_page.dart';
 import 'add_departement_page.dart';
+import '../services/emploi_generator.dart';
 
 class DashboardPage extends StatelessWidget {
   const DashboardPage({super.key});
@@ -54,6 +55,32 @@ class DashboardPage extends StatelessWidget {
               },
               icon: const Icon(Icons.calendar_today),
               label: const Text("Générer Emploi du temps"),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.teal,
+                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+                textStyle: const TextStyle(fontSize: 16),
+              ),
+              ),
+            const SizedBox(height: 12),
+            ElevatedButton.icon(
+              onPressed: () async {
+                try {
+                  await EmploiGenerator().importerDepuisFichier('assets/emploi_test.json');
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Import JSON réussi ✅')),
+                    );
+                  }
+                } catch (e) {
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text('Erreur : ' + e.toString())),
+                    );
+                  }
+                }
+              },
+              icon: const Icon(Icons.upload_file),
+              label: const Text('Importer depuis JSON'),
               style: ElevatedButton.styleFrom(
                 backgroundColor: Colors.teal,
                 padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),

--- a/lib/services/emploi_generator.dart
+++ b/lib/services/emploi_generator.dart
@@ -1,4 +1,6 @@
+import 'dart:convert';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/services.dart' show rootBundle;
 
 class EmploiGenerator {
   final FirebaseFirestore _db = FirebaseFirestore.instance;
@@ -168,5 +170,12 @@ class EmploiGenerator {
         'salle': salleId,
       });
     }
+  }
+
+  /// 📄 Charge un fichier JSON d'emplois local et l'importe dans Firestore
+  Future<void> importerDepuisFichier(String path) async {
+    final contenu = await rootBundle.loadString(path);
+    final Map<String, dynamic> data = json.decode(contenu) as Map<String, dynamic>;
+    await importerDepuisJson(data);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,3 +34,5 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  assets:
+    - assets/emploi_test.json


### PR DESCRIPTION
## Summary
- add local JSON sample
- enable asset in pubspec
- add helper to import schedule from JSON file
- call import from Dashboard

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e6a85e168832da9f733a8eeba649f