### PR TITLE
Fix import emplois route precedence

### DIFF
--- a/backend/emploi_django/api/urls.py
+++ b/backend/emploi_django/api/urls.py
@@ -19,10 +19,10 @@ router.register(r'emplois', EmploiViewSet)
 
 # Définition des URLs
 urlpatterns = [
-    path('', include(router.urls)),
-
-    # ✅ Routes personnalisées
+    # ✅ Routes personnalisées d'abord pour éviter les conflits avec le router
     path('emplois/generate/', generer_emplois, name='generer_emplois'),
     path('emplois/classe/<int:classe_id>/', emploi_par_classe, name='emploi_par_classe'),
     path('emplois/import/', import_emplois, name='import_emplois'),
+
+    path('', include(router.urls)),
 ]


### PR DESCRIPTION
## Summary
- ensure `/api/emplois/import/` is matched before router URLs by moving custom URL patterns above router include

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686849c0b95c832d82493c674f4a204f