### PR TITLE
Add cross-platform run script

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ flutter run -d linux     # sur Linux
 flutter run -d chrome    # Web
 ```
 
+### Lancement automatique multi-plateforme
+
+Un script `run_all.py` permet de démarrer le serveur Django puis
+l'application Flutter sur la plateforme détectée. Exécutez simplement :
+
+```bash
+python run_all.py
+```
+
 ## 🗄️ Base de données SQLite
 
 - **Django :** `backend/emploi_django/db.sqlite3`

--- a/run_all.py
+++ b/run_all.py
@@ -1,0 +1,27 @@
+import os
+import platform
+import subprocess
+import sys
+
+
+PLATFORM_MAP = {
+    "Windows": "windows",
+    "Darwin": "macos",
+    "Linux": "linux",
+}
+
+
+def main():
+    # Start Django backend
+    backend = subprocess.Popen([sys.executable, "start_servers.py"])
+
+    try:
+        target = PLATFORM_MAP.get(platform.system(), "chrome")
+        print(f"Running Flutter app on: {target}")
+        subprocess.run(["flutter", "run", "-d", target], check=True)
+    finally:
+        backend.terminate()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run_all.py` script to start the backend and run Flutter on the current platform
- document new script in README

## Testing
- `python backend/emploi_django/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6872dd63a710832d9f685f1ef7cd7130