### PR TITLE
Fix salle/classe forms POST and confirm dialogs

### DIFF
--- a/lib/pages/add_classe_form.dart
+++ b/lib/pages/add_classe_form.dart
@@ -30,44 +30,44 @@ class _AddClasseFormState extends State<AddClasseForm> {
     setState(() => _isLoading = true);
 
     try {
-      await ApiService.addClasse(data);
+      await ApiService.post('/classes/', data);
 
       if (!mounted) return;
       await showDialog<void>(
-        context: context,
-        builder: (_) => AlertDialog(
-          title: const Text('✅ Élément enregistré avec succès'),
-          content:
-              const Text('Voulez-vous voir la liste ou ajouter un nouveau ?'),
-          actions: [
-            TextButton(
-              onPressed: () {
-                Navigator.pop(context);
-                Navigator.pushReplacement(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => const EntityListPage(
-                      endpoint: 'classes/',
-                      fieldsToShow: ['nom', 'filiere', 'effectif'],
+          context: context,
+          builder: (_) => AlertDialog(
+            title: const Text('✅ Élément enregistré avec succès'),
+            content:
+                const Text('Voulez-vous voir la liste ou ajouter un nouveau ?'),
+            actions: [
+              TextButton(
+                onPressed: () {
+                  Navigator.pop(context);
+                  Navigator.pushReplacement(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const EntityListPage(
+                        endpoint: 'classes/',
+                        fieldsToShow: ['nom', 'filiere', 'effectif'],
+                      ),
                     ),
-                  ),
-                );
-              },
-              child: const Text('Voir la liste'),
-            ),
-            TextButton(
-              onPressed: () {
-                Navigator.pop(context);
-                _formKey.currentState!.reset();
-                _nomController.clear();
-                _effectifController.clear();
-                setState(() => _selectedFiliereId = null);
-              },
-              child: const Text('Ajouter un nouvel élément'),
-            ),
-          ],
-        ),
-      );
+                  );
+                },
+                child: const Text('Voir la liste'),
+              ),
+              TextButton(
+                onPressed: () {
+                  Navigator.pop(context);
+                  _formKey.currentState!.reset();
+                  _nomController.clear();
+                  _effectifController.clear();
+                  setState(() => _selectedFiliereId = null);
+                },
+                child: const Text('Ajouter un nouvel élément'),
+              ),
+            ],
+          ),
+        );
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context)

--- a/lib/pages/add_salle_form.dart
+++ b/lib/pages/add_salle_form.dart
@@ -28,7 +28,7 @@ class _AddSalleFormState extends State<AddSalleForm> {
     setState(() => _isLoading = true);
 
     try {
-      await ApiService.addSalle(data);
+      await ApiService.post('/salles/', data);
 
       if (!mounted) return;
       await showDialog<void>(


### PR DESCRIPTION
## Summary
- fix POST submission for salle and classe using ApiService.post
- ensure success dialogs appear with navigation options

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873ba4140ac832db16e0b0f490d1a22