### PR TITLE
Ajout popup de confirmation après création

### DIFF
--- a/lib/pages/add_classe_form.dart
+++ b/lib/pages/add_classe_form.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import '../services/api_service.dart';
+import 'entity_list_page.dart';
+import '../widgets/confirmation_dialog.dart';
 
 class AddClasseForm extends StatefulWidget {
   const AddClasseForm({Key? key}) : super(key: key);
@@ -106,15 +108,31 @@ class _AddClasseFormState extends State<AddClasseForm> {
 
                     await ApiService.addClasse(data);
 
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text('Classe enregistrée avec succès')),
+                    if (!mounted) return;
+                    await ConfirmationDialog.showSuccessDialog(
+                      context: context,
+                      viewButtonText: 'Voir la liste des classes',
+                      addButtonText: 'Ajouter une nouvelle classe',
+                      onViewList: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => const EntityListPage(
+                              endpoint: 'classes/',
+                              fieldsToShow: ['nom', 'filiere', 'effectif'],
+                            ),
+                          ),
+                        );
+                      },
+                      onAddNew: () {
+                        _formKey.currentState!.reset();
+                        _nomController.clear();
+                        _effectifController.clear();
+                        setState(() {
+                          _selectedFiliereId = null;
+                        });
+                      },
                     );
-
-                    _nomController.clear();
-                    _effectifController.clear();
-                    setState(() {
-                      _selectedFiliereId = null;
-                    });
                   }
                 },
                 child: const Text('Enregistrer'),

--- a/lib/pages/add_filiere_form.dart
+++ b/lib/pages/add_filiere_form.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import '../services/api_service.dart';
+import 'entity_list_page.dart';
+import '../widgets/confirmation_dialog.dart';
 
 class AddFiliereForm extends StatefulWidget {
   const AddFiliereForm({Key? key}) : super(key: key);
@@ -29,12 +31,28 @@ class _AddFiliereFormState extends State<AddFiliereForm> {
 
       try {
         await ApiService.addFiliere(data);
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Filière ajoutée avec succès')),
+        if (!mounted) return;
+        await ConfirmationDialog.showSuccessDialog(
+          context: context,
+          viewButtonText: 'Voir la liste des filières',
+          addButtonText: 'Ajouter une nouvelle filière',
+          onViewList: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => const EntityListPage(
+                  endpoint: 'filieres/',
+                  fieldsToShow: ['nom', 'departement'],
+                ),
+              ),
+            );
+          },
+          onAddNew: () {
+            _formKey.currentState!.reset();
+            _nomController.clear();
+            _departementController.clear();
+          },
         );
-        _formKey.currentState!.reset();
-        _nomController.clear();
-        _departementController.clear();
       } catch (e) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(content: Text('Erreur : $e')),

--- a/lib/pages/add_module_page.dart
+++ b/lib/pages/add_module_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import '../services/api_service.dart';
+import 'module_list_page.dart';
+import '../widgets/confirmation_dialog.dart';
 
 class AddModulePage extends StatefulWidget {
   final int? moduleId;
@@ -87,12 +89,29 @@ class _AddModulePageState extends State<AddModulePage> {
         await ApiService.updateModule(widget.moduleId!.toString(), data);
       }
 
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text("✅ Module enregistré avec succès")),
-        );
-        Navigator.pop(context);
-      }
+      if (!mounted) return;
+      await ConfirmationDialog.showSuccessDialog(
+        context: context,
+        viewButtonText: 'Voir la liste des modules',
+        addButtonText: 'Ajouter un nouveau module',
+        onViewList: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => const ModuleListPage()),
+          );
+        },
+        onAddNew: () {
+          _formKey.currentState!.reset();
+          _nomController.clear();
+          setState(() {
+            _selectedJour = null;
+            _selectedHeure = null;
+            _selectedClasse = null;
+            _selectedSalle = null;
+            _selectedProf = null;
+          });
+        },
+      );
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/pages/add_professeur_form.dart
+++ b/lib/pages/add_professeur_form.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import '../services/api_service.dart';
+import 'entity_list_page.dart';
+import '../widgets/confirmation_dialog.dart';
 
 class AddProfesseurForm extends StatefulWidget {
   const AddProfesseurForm({Key? key}) : super(key: key);
@@ -22,8 +24,28 @@ class _AddProfesseurFormState extends State<AddProfesseurForm> {
 
       try {
         await ApiService.addProfesseur(data);
-        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text("Professeur ajouté")));
-        _formKey.currentState!.reset();
+        if (!mounted) return;
+        await ConfirmationDialog.showSuccessDialog(
+          context: context,
+          viewButtonText: 'Voir la liste des professeurs',
+          addButtonText: 'Ajouter un nouveau professeur',
+          onViewList: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => const EntityListPage(
+                  endpoint: 'professeurs/',
+                  fieldsToShow: ['nom'],
+                ),
+              ),
+            );
+          },
+          onAddNew: () {
+            _formKey.currentState!.reset();
+            _nomController.clear();
+            _dispoController.clear();
+          },
+        );
       } catch (e) {
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text("Erreur: $e")));
       }

--- a/lib/pages/add_salle_form.dart
+++ b/lib/pages/add_salle_form.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import '../services/api_service.dart';
+import '../pages/entity_list_page.dart';
+import '../widgets/confirmation_dialog.dart';
 
 class AddSalleForm extends StatefulWidget {
   const AddSalleForm({Key? key}) : super(key: key);
@@ -24,9 +26,29 @@ class _AddSalleFormState extends State<AddSalleForm> {
 
       try {
         await ApiService.addSalle(data);
-        ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text("Salle ajoutée")));
-        _formKey.currentState!.reset();
-        setState(() => _disponible = true);
+        if (!mounted) return;
+        await ConfirmationDialog.showSuccessDialog(
+          context: context,
+          viewButtonText: 'Voir la liste des salles',
+          addButtonText: 'Ajouter une nouvelle salle',
+          onViewList: () {
+            Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => const EntityListPage(
+                  endpoint: 'salles/',
+                  fieldsToShow: ['nom', 'capacité', 'disponible'],
+                ),
+              ),
+            );
+          },
+          onAddNew: () {
+            _formKey.currentState!.reset();
+            _nomController.clear();
+            _capaciteController.clear();
+            setState(() => _disponible = true);
+          },
+        );
       } catch (e) {
         ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text("Erreur: $e")));
       }

--- a/lib/widgets/confirmation_dialog.dart
+++ b/lib/widgets/confirmation_dialog.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+class ConfirmationDialog {
+  static Future<void> showSuccessDialog({
+    required BuildContext context,
+    required String viewButtonText,
+    required String addButtonText,
+    required VoidCallback onViewList,
+    required VoidCallback onAddNew,
+  }) {
+    return showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Succès'),
+        content: const Text('Enregistrement effectué avec succès.'),
+        actions: [
+          TextButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+              onAddNew();
+            },
+            child: Text(addButtonText),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+              onViewList();
+            },
+            child: Text(viewButtonText),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create reusable `ConfirmationDialog` widget
- afficher une boîte de dialogue après ajout d'une salle, d'une classe, d'un professeur, d'un module ou d'une filière
- proposer "Voir la liste" ou "Ajouter un nouveau" sur chaque formulaire

## Testing
- `flutter test` *(fails: command not found)*
- `python backend/emploi_django/manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687559bad1b4832d8024331e821c9ba4