### PR TITLE
Add global timetable generation by department

### DIFF
--- a/backend/emploi_django/api/models.py
+++ b/backend/emploi_django/api/models.py
@@ -3,6 +3,14 @@ from django.db import models
 # -------- FILIERE --------
 class Filiere(models.Model):
     nom = models.CharField(max_length=100)
+    # Association au département de rattachement
+    departement = models.ForeignKey(
+        'Departement',
+        on_delete=models.CASCADE,
+        related_name='filieres',
+        null=True,
+        blank=True,
+    )
 
     def __str__(self):
         return self.nom

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -154,6 +154,21 @@ class ApiService {
     if (response.statusCode != 200) throw Exception('❌ Failed to generate emplois');
   }
 
+  static Future<Map<String, dynamic>> generateEmploisParDepartements(
+      List<int> departements) async {
+    final response = await http.post(
+      Uri.parse('$baseUrl/emplois/generate/'),
+      headers: _headers,
+      body: jsonEncode({'departements': departements}),
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception('❌ Failed to generate emplois: ${response.body}');
+    }
+
+    return jsonDecode(response.body) as Map<String, dynamic>;
+  }
+
   static Future<void> importEmplois(Map<String, dynamic> data) async {
     // Envoyer directement les données sans conversion d'IDs
     // L'API Django s'occupera de créer les éléments manquants


### PR DESCRIPTION
## Summary
- link filière to département
- generate timetable for selected departments with conflict checks
- expose API to generate timetable for multiple departments
- call new endpoint from Flutter
- add UI to pick multiple departments and display tables

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876cab7ff3c832d916100a1729ebe41